### PR TITLE
Fix #7

### DIFF
--- a/Example/ExampleTests/WeatherViewControllerTests.swift
+++ b/Example/ExampleTests/WeatherViewControllerTests.swift
@@ -32,49 +32,49 @@ class WeatherViewControllerTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    func test_天気予報がsunnyだったらImageViewのImageにsunnyが設定されること_TintColorがredに設定されること() throws {
+    func test_天気予報がsunnyだったらImageViewのImageにsunnyが設定されること_TintColorがredに設定されること() async throws {
         weatherModel.fetchWeatherImpl = { _ in
             Response(weather: .sunny, maxTemp: 0, minTemp: 0, date: Date())
         }
 
-        weatherViewController.loadWeather(nil)
-        DispatchQueue.main.async {
+        await weatherViewController.loadWeather(nil)
+        await MainActor.run {
             XCTAssertEqual(self.weatherViewController.weatherImageView.tintColor, R.color.red())
             XCTAssertEqual(self.weatherViewController.weatherImageView.image, R.image.sunny())
         }
     }
     
-    func test_天気予報がcloudyだったらImageViewのImageにcloudyが設定されること_TintColorがgrayに設定されること() throws {
+    func test_天気予報がcloudyだったらImageViewのImageにcloudyが設定されること_TintColorがgrayに設定されること() async throws {
         weatherModel.fetchWeatherImpl = { _ in
             Response(weather: .cloudy, maxTemp: 0, minTemp: 0, date: Date())
         }
         
-        weatherViewController.loadWeather(nil)
-        DispatchQueue.main.async {
+        await weatherViewController.loadWeather(nil)
+        await MainActor.run {
             XCTAssertEqual(self.weatherViewController.weatherImageView.tintColor, R.color.gray())
             XCTAssertEqual(self.weatherViewController.weatherImageView.image, R.image.cloudy())
         }
     }
     
-    func test_天気予報がrainyだったらImageViewのImageにrainyが設定されること_TintColorがblueに設定されること() throws {
+    func test_天気予報がrainyだったらImageViewのImageにrainyが設定されること_TintColorがblueに設定されること() async throws {
         weatherModel.fetchWeatherImpl = { _ in
             Response(weather: .rainy, maxTemp: 0, minTemp: 0, date: Date())
         }
         
-        weatherViewController.loadWeather(nil)
-        DispatchQueue.main.async {
+        await weatherViewController.loadWeather(nil)
+        await MainActor.run {
             XCTAssertEqual(self.weatherViewController.weatherImageView.tintColor, R.color.blue())
             XCTAssertEqual(self.weatherViewController.weatherImageView.image, R.image.rainy())
         }
     }
     
-    func test_最高気温_最低気温がUILabelに設定されること() throws {
+    func test_最高気温_最低気温がUILabelに設定されること() async throws {
         weatherModel.fetchWeatherImpl = { _ in
             Response(weather: .rainy, maxTemp: 100, minTemp: -100, date: Date())
         }
         
-        weatherViewController.loadWeather(nil)
-        DispatchQueue.main.async {
+        await weatherViewController.loadWeather(nil)
+        await MainActor.run {
             XCTAssertEqual(self.weatherViewController.minTempLabel.text, "-100")
             XCTAssertEqual(self.weatherViewController.maxTempLabel.text, "100")
         }

--- a/Example/ExampleTests/WeatherViewControllerTests.swift
+++ b/Example/ExampleTests/WeatherViewControllerTests.swift
@@ -31,7 +31,7 @@ class WeatherViewControllerTests: XCTestCase {
             Response(weather: .sunny, maxTemp: 0, minTemp: 0, date: Date())
         }
         
-        weahterViewController.loadWeather()
+        weahterViewController.loadWeather(nil)
         XCTAssertEqual(weahterViewController.weatherImageView.tintColor, R.color.red())
         XCTAssertEqual(weahterViewController.weatherImageView.image, R.image.sunny())
     }
@@ -41,7 +41,7 @@ class WeatherViewControllerTests: XCTestCase {
             Response(weather: .cloudy, maxTemp: 0, minTemp: 0, date: Date())
         }
         
-        weahterViewController.loadWeather()
+        weahterViewController.loadWeather(nil)
         XCTAssertEqual(weahterViewController.weatherImageView.tintColor, R.color.gray())
         XCTAssertEqual(weahterViewController.weatherImageView.image, R.image.cloudy())
     }
@@ -51,7 +51,7 @@ class WeatherViewControllerTests: XCTestCase {
             Response(weather: .rainy, maxTemp: 0, minTemp: 0, date: Date())
         }
         
-        weahterViewController.loadWeather()
+        weahterViewController.loadWeather(nil)
         XCTAssertEqual(weahterViewController.weatherImageView.tintColor, R.color.blue())
         XCTAssertEqual(weahterViewController.weatherImageView.image, R.image.rainy())
     }
@@ -61,7 +61,7 @@ class WeatherViewControllerTests: XCTestCase {
             Response(weather: .rainy, maxTemp: 100, minTemp: -100, date: Date())
         }
         
-        weahterViewController.loadWeather()
+        weahterViewController.loadWeather(nil)
         XCTAssertEqual(weahterViewController.minTempLabel.text, "-100")
         XCTAssertEqual(weahterViewController.maxTempLabel.text, "100")
     }
@@ -73,5 +73,14 @@ class WeatherModelMock: WeatherModel {
     
     func fetchWeather(_ request: Request) throws -> Response {
         return try fetchWeatherImpl(request)
+    }
+
+    func fetchWeather(at area: String, date: Date, completion: @escaping (Result<Example.Response, Example.WeatherError>) -> Void) {
+        let request = Request(area: area, date: date)
+        if let response = try? fetchWeather(request) {
+            completion(.success(response))
+        } else {
+            completion(.failure(WeatherError.unknownError))
+        }
     }
 }

--- a/Example/ExampleTests/WeatherViewControllerTests.swift
+++ b/Example/ExampleTests/WeatherViewControllerTests.swift
@@ -12,20 +12,20 @@ import YumemiWeather
 
 class WeatherViewControllerTests: XCTestCase {
 
-    var weahterViewController: WeatherViewController!
-    var weahterModel: WeatherModelMock!
+    var weatherViewController: WeatherViewController!
+    var weatherModel: WeatherModelMock!
     var disasterModel: DisasterModelMock!
 
     override func setUpWithError() throws {
-        weahterModel = WeatherModelMock()
+        weatherModel = WeatherModelMock()
         disasterModel = DisasterModelMock()
         disasterModel.fetchDisasterImpl = {
             "只今、災害情報はありません。"
         }
-        weahterViewController = R.storyboard.weather.instantiateInitialViewController()!
-        weahterViewController.weatherModel = weahterModel
-        weahterViewController.disasterModel = disasterModel
-        _ = weahterViewController.view
+        weatherViewController = R.storyboard.weather.instantiateInitialViewController()!
+        weatherViewController.weatherModel = weatherModel
+        weatherViewController.disasterModel = disasterModel
+        _ = weatherViewController.view
     }
 
     override func tearDownWithError() throws {
@@ -33,50 +33,50 @@ class WeatherViewControllerTests: XCTestCase {
     }
 
     func test_天気予報がsunnyだったらImageViewのImageにsunnyが設定されること_TintColorがredに設定されること() throws {
-        weahterModel.fetchWeatherImpl = { _ in
+        weatherModel.fetchWeatherImpl = { _ in
             Response(weather: .sunny, maxTemp: 0, minTemp: 0, date: Date())
         }
 
-        weahterViewController.loadWeather(nil)
+        weatherViewController.loadWeather(nil)
         DispatchQueue.main.async {
-            XCTAssertEqual(self.weahterViewController.weatherImageView.tintColor, R.color.red())
-            XCTAssertEqual(self.weahterViewController.weatherImageView.image, R.image.sunny())
+            XCTAssertEqual(self.weatherViewController.weatherImageView.tintColor, R.color.red())
+            XCTAssertEqual(self.weatherViewController.weatherImageView.image, R.image.sunny())
         }
     }
     
     func test_天気予報がcloudyだったらImageViewのImageにcloudyが設定されること_TintColorがgrayに設定されること() throws {
-        weahterModel.fetchWeatherImpl = { _ in
+        weatherModel.fetchWeatherImpl = { _ in
             Response(weather: .cloudy, maxTemp: 0, minTemp: 0, date: Date())
         }
         
-        weahterViewController.loadWeather(nil)
+        weatherViewController.loadWeather(nil)
         DispatchQueue.main.async {
-            XCTAssertEqual(self.weahterViewController.weatherImageView.tintColor, R.color.gray())
-            XCTAssertEqual(self.weahterViewController.weatherImageView.image, R.image.cloudy())
+            XCTAssertEqual(self.weatherViewController.weatherImageView.tintColor, R.color.gray())
+            XCTAssertEqual(self.weatherViewController.weatherImageView.image, R.image.cloudy())
         }
     }
     
     func test_天気予報がrainyだったらImageViewのImageにrainyが設定されること_TintColorがblueに設定されること() throws {
-        weahterModel.fetchWeatherImpl = { _ in
+        weatherModel.fetchWeatherImpl = { _ in
             Response(weather: .rainy, maxTemp: 0, minTemp: 0, date: Date())
         }
         
-        weahterViewController.loadWeather(nil)
+        weatherViewController.loadWeather(nil)
         DispatchQueue.main.async {
-            XCTAssertEqual(self.weahterViewController.weatherImageView.tintColor, R.color.blue())
-            XCTAssertEqual(self.weahterViewController.weatherImageView.image, R.image.rainy())
+            XCTAssertEqual(self.weatherViewController.weatherImageView.tintColor, R.color.blue())
+            XCTAssertEqual(self.weatherViewController.weatherImageView.image, R.image.rainy())
         }
     }
     
     func test_最高気温_最低気温がUILabelに設定されること() throws {
-        weahterModel.fetchWeatherImpl = { _ in
+        weatherModel.fetchWeatherImpl = { _ in
             Response(weather: .rainy, maxTemp: 100, minTemp: -100, date: Date())
         }
         
-        weahterViewController.loadWeather(nil)
+        weatherViewController.loadWeather(nil)
         DispatchQueue.main.async {
-            XCTAssertEqual(self.weahterViewController.minTempLabel.text, "-100")
-            XCTAssertEqual(self.weahterViewController.maxTempLabel.text, "100")
+            XCTAssertEqual(self.weatherViewController.minTempLabel.text, "-100")
+            XCTAssertEqual(self.weatherViewController.maxTempLabel.text, "100")
         }
     }
 }

--- a/Example/ExampleTests/WeatherViewControllerTests.swift
+++ b/Example/ExampleTests/WeatherViewControllerTests.swift
@@ -14,11 +14,17 @@ class WeatherViewControllerTests: XCTestCase {
 
     var weahterViewController: WeatherViewController!
     var weahterModel: WeatherModelMock!
-    
+    var disasterModel: DisasterModelMock!
+
     override func setUpWithError() throws {
         weahterModel = WeatherModelMock()
+        disasterModel = DisasterModelMock()
+        disasterModel.fetchDisasterImpl = {
+            "只今、災害情報はありません。"
+        }
         weahterViewController = R.storyboard.weather.instantiateInitialViewController()!
         weahterViewController.weatherModel = weahterModel
+        weahterViewController.disasterModel = disasterModel
         _ = weahterViewController.view
     }
 
@@ -82,5 +88,14 @@ class WeatherModelMock: WeatherModel {
         } else {
             completion(.failure(WeatherError.unknownError))
         }
+    }
+}
+
+class DisasterModelMock: DisasterModel {
+
+    var fetchDisasterImpl: (() -> String)!
+
+    func fetchDisaster(completion: ((String) -> Void)?) {
+        completion?(fetchDisasterImpl())
     }
 }

--- a/Example/ExampleTests/WeatherViewControllerTests.swift
+++ b/Example/ExampleTests/WeatherViewControllerTests.swift
@@ -36,10 +36,12 @@ class WeatherViewControllerTests: XCTestCase {
         weahterModel.fetchWeatherImpl = { _ in
             Response(weather: .sunny, maxTemp: 0, minTemp: 0, date: Date())
         }
-        
+
         weahterViewController.loadWeather(nil)
-        XCTAssertEqual(weahterViewController.weatherImageView.tintColor, R.color.red())
-        XCTAssertEqual(weahterViewController.weatherImageView.image, R.image.sunny())
+        DispatchQueue.main.async {
+            XCTAssertEqual(self.weahterViewController.weatherImageView.tintColor, R.color.red())
+            XCTAssertEqual(self.weahterViewController.weatherImageView.image, R.image.sunny())
+        }
     }
     
     func test_天気予報がcloudyだったらImageViewのImageにcloudyが設定されること_TintColorがgrayに設定されること() throws {
@@ -48,8 +50,10 @@ class WeatherViewControllerTests: XCTestCase {
         }
         
         weahterViewController.loadWeather(nil)
-        XCTAssertEqual(weahterViewController.weatherImageView.tintColor, R.color.gray())
-        XCTAssertEqual(weahterViewController.weatherImageView.image, R.image.cloudy())
+        DispatchQueue.main.async {
+            XCTAssertEqual(self.weahterViewController.weatherImageView.tintColor, R.color.gray())
+            XCTAssertEqual(self.weahterViewController.weatherImageView.image, R.image.cloudy())
+        }
     }
     
     func test_天気予報がrainyだったらImageViewのImageにrainyが設定されること_TintColorがblueに設定されること() throws {
@@ -58,8 +62,10 @@ class WeatherViewControllerTests: XCTestCase {
         }
         
         weahterViewController.loadWeather(nil)
-        XCTAssertEqual(weahterViewController.weatherImageView.tintColor, R.color.blue())
-        XCTAssertEqual(weahterViewController.weatherImageView.image, R.image.rainy())
+        DispatchQueue.main.async {
+            XCTAssertEqual(self.weahterViewController.weatherImageView.tintColor, R.color.blue())
+            XCTAssertEqual(self.weahterViewController.weatherImageView.image, R.image.rainy())
+        }
     }
     
     func test_最高気温_最低気温がUILabelに設定されること() throws {
@@ -68,8 +74,10 @@ class WeatherViewControllerTests: XCTestCase {
         }
         
         weahterViewController.loadWeather(nil)
-        XCTAssertEqual(weahterViewController.minTempLabel.text, "-100")
-        XCTAssertEqual(weahterViewController.maxTempLabel.text, "100")
+        DispatchQueue.main.async {
+            XCTAssertEqual(self.weahterViewController.minTempLabel.text, "-100")
+            XCTAssertEqual(self.weahterViewController.maxTempLabel.text, "100")
+        }
     }
 }
 


### PR DESCRIPTION
# Updates
- Fix #7 
  - WeatherViewControllerのloadWeatherに引数`(_ sender: Any)`を渡すように変更
  - WeatherModelMockにfetchWeatherを追加実装
  - DisasterModelMockを追加実装
  - XCTAssertの評価をメインスレッドで行うように変更
  - typoを修正 (weahter -> weather)